### PR TITLE
Remove duplicate "DESCRIPTRION" entry from Neon.fs

### DIFF
--- a/ISF/Neon.fs
+++ b/ISF/Neon.fs
@@ -1,5 +1,4 @@
 /*{
-	"DESCRIPTION": "",
 	"CREDIT": "by VIDVOX",
 	"ISFVSN": "2",
 	"DESCRIPTION": "adapted from https://github.com/neilmendoza/ofxPostProcessing/blob/master/src/GodRaysPass.cpp",


### PR DESCRIPTION
Noticed this while working on my `isf` Rust lib!